### PR TITLE
add new hook: useSelector

### DIFF
--- a/src/components/HandSelector/HandSelector.js
+++ b/src/components/HandSelector/HandSelector.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Rock, Paper, Scissors, Lizard, Spock } from "../../Hand";
 import { ChooseHand, StartRound } from "../../namespace/events";
-import { useNamespace } from "../../react-signal/hooks";
+import { useNamespace, useSelector } from "../../react-signal/hooks";
 
 const handCoords = [
   { hand: Rock, coords: "175, 75, 60" },
@@ -11,8 +11,11 @@ const handCoords = [
   { hand: Spock, coords: "75, 155, 60" },
 ];
 
-export const HandSelector = ({ inGame }) => {
+export const inGameSelector = ({ sheldonState }) => sheldonState === "thinking";
+
+export const HandSelector = () => {
   const { trigger } = useNamespace();
+  const inGame = useSelector(inGameSelector);
 
   const onImageClick = () => inGame || trigger(StartRound);
   return (
@@ -44,7 +47,3 @@ export const HandSelector = ({ inGame }) => {
     </div>
   );
 };
-
-export const mapStateToProps = ({ sheldonState }) => ({
-  inGame: sheldonState === "thinking",
-});

--- a/src/components/HandSelector/index.js
+++ b/src/components/HandSelector/index.js
@@ -1,4 +1,3 @@
-import Connect from "../../react-signal";
-import { HandSelector, mapStateToProps } from "./HandSelector";
+import { HandSelector } from "./HandSelector";
 
-export default Connect(HandSelector, mapStateToProps);
+export default HandSelector;

--- a/src/react-signal/event-hive/control.js
+++ b/src/react-signal/event-hive/control.js
@@ -95,10 +95,20 @@ function fnName(fn) {
 
   const def = fn.toString().match(/_this[0-9]?\.([a-zA-Z_$]+)\(/i);
   if (!def) {
-    const functionNames = fn.toString().match(/[a-zA-Z_]+\([^)]*\)/g);
+    let functionNames = fn.toString().match(/[a-zA-Z_]+\([^)]*\)/g);
 
     if (functionNames && functionNames.length) {
-      return "'" + functionNames.map((n) => n.split("(")[0]).join("|") + "'";
+      return (
+        "'" +
+        functionNames
+          .map((n) => n.split("(")[0])
+          .reduce((a, c) => {
+            if (c === a[a.length - 1]) return a;
+            return [...a, c];
+          }, [])
+          .join("|") +
+        "'"
+      );
     }
   }
 

--- a/src/react-signal/hooks.js
+++ b/src/react-signal/hooks.js
@@ -1,10 +1,13 @@
 import {
   useContext,
   useEffect,
+  useState,
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
 } from "react";
 import { NamespaceCtx } from "./";
+import { extractProps } from "./connect/util";
 import Control from "./event-hive/control";
+import { StateChanged } from "./event-hive/namespace";
 
 const getInstance = () => {
   const __fiberNode =
@@ -24,7 +27,6 @@ export function useNamespace() {
 
   return {
     trigger: (...a) => Control.withActor(instance, namespace).trigger(...a),
-    state: namespace.state,
   };
 }
 
@@ -44,4 +46,25 @@ export function useListeners(...listeners) {
   return {
     trigger: (...a) => Control.withActor(instance, namespace).trigger(...a),
   };
+}
+
+export function useSelector(selectorFn) {
+  const namespace = useContext(NamespaceCtx);
+  const [state, refreshSelector] = useState(namespace.state);
+  const watchedProps = extractProps(selectorFn);
+
+  useListeners(StateChanged, () => {
+    if (watchedProps) {
+      for (let prop of watchedProps) {
+        if (namespace._propsChanged[prop]) {
+          refreshSelector({ ...namespace.state });
+          return;
+        }
+      }
+      return;
+    }
+    refreshSelector({ ...namespace.state });
+  });
+
+  return selectorFn(state);
 }


### PR DESCRIPTION
Added new hook to avoid Connect() for simple state watchers.

We might need some optimisation later on for when multiple selectors are being used on the same component. Now it would add all the StateChanged listeners separately when it could be added all together somehow.